### PR TITLE
fix: Missing dependencies

### DIFF
--- a/chat/public/js/chat.bundle.js
+++ b/chat/public/js/chat.bundle.js
@@ -7,7 +7,6 @@ import {
   ChatSpace,
   ChatWelcome,
   get_settings,
-  setup_dependencies,
   scroll_to_bottom,
 } from './components';
 frappe.provide('frappe.Chat');
@@ -72,7 +71,7 @@ frappe.Chat = class {
       }
 
       this.create_app();
-      await setup_dependencies(res.socketio_port);
+      await frappe.socketio.init(res.socketio_port);
 
       frappe.Chat.settings = {};
       frappe.Chat.settings.user = res.user_settings;

--- a/chat/public/js/components/chat_utils.js
+++ b/chat/public/js/components/chat_utils.js
@@ -110,17 +110,6 @@ async function mark_message_read(room) {
   }
 }
 
-async function setup_dependencies(socketio_port) {
-  await frappe.require(
-    [
-      'assets/frappe/js/lib/socket.io.min.js',
-      'assets/frappe/js/frappe/socketio_client.js',
-    ],
-    () => {
-      frappe.socketio.init(socketio_port);
-    }
-  );
-}
 
 async function create_guest({ email, full_name, message }) {
   const res = await frappe.call({
@@ -203,7 +192,6 @@ export {
   get_settings,
   create_guest,
   send_message,
-  setup_dependencies,
   get_date_from_now,
   is_date_change,
   mark_message_read,


### PR DESCRIPTION
frappe no longer provides socketio.min.js 

<img width="661" alt="Screenshot 2022-07-08 at 10 49 42" src="https://user-images.githubusercontent.com/1424733/177956887-7aee6efc-5a90-4247-83c9-2b68d948b24e.png">

In fact removing both dependencies makes the chat app function normally in both desk and outside.