### PR TITLE
fix: Dont show chat button if user role is restricted

### DIFF
--- a/chat/utils/__init__.py
+++ b/chat/utils/__init__.py
@@ -85,10 +85,13 @@ def get_chat_settings():
     user_roles = frappe.get_roles()
 
     allowed_roles = [u.role for u in chat_settings.allowed_roles]
-    allowed_roles.extend(['System Manager', 'Administrator', 'Guest'])
+    allowed_roles.extend(['System Manager', 'Administrator'])
     result = {
         'enable_chat': False
     }
+
+    if frappe.session.user == 'Guest':
+        result['enable_chat'] = True
 
     if not chat_settings.enable_chat or not has_common(allowed_roles, user_roles):
         return result


### PR DESCRIPTION
We have the option to restrict the chat feature in chat settings through the roles table. But it doesn't work because every user has a 'Guest' role and while checking if the user has common roles compared with roles added in the roles table it always returns true because the roles table was extended with ['All', 'Guest'].

<img width="1295" alt="image" src="https://user-images.githubusercontent.com/30859809/187351792-bb97d2a2-c694-4289-8bc8-8984e33c18c7.png">


<img width="548" alt="image" src="https://user-images.githubusercontent.com/30859809/187351903-b7f04d90-36f6-4d5b-883d-6f68dc4b57be.png">
