### PR TITLE
feat: Chat operator to communicate with guest user

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -6,7 +6,7 @@ cd ~ || exit
 
 pip install frappe-bench
 
-bench init frappe-bench --skip-assets --python "$(which python)"	
+bench init frappe-bench --skip-assets --python "$(which python)"
 
 mkdir ~/frappe-bench/sites/test_site
 cp "${GITHUB_WORKSPACE}/.github/helper/consumer_db/$DB.json" ~/frappe-bench/sites/test_site/site_config.json
@@ -31,11 +31,6 @@ sed -i 's/^watch:/# watch:/g' Procfile
 sed -i 's/^schedule:/# schedule:/g' Procfile
 
 bench setup requirements --node
-
-# install node-sass which is required for website theme test
-cd ./apps/frappe || exit
-yarn add node-sass@4.13.1
-cd ../..
 
 bench get-app chat "${GITHUB_WORKSPACE}"
 

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -35,11 +35,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: '3.10'
 
       - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 16
           check-latest: true
 
       - name: Add to Hosts
@@ -104,7 +104,10 @@ jobs:
         run: cd ~/frappe-bench/ && bench --site test_site execute frappe.utils.install.complete_setup_wizard
 
       - name: Cypress pre-requisites
-        run: cd ~/frappe-bench/apps/frappe && yarn add cypress-file-upload@^5 @testing-library/cypress@^8 --no-lockfile && bench --site test_site execute chat.utils.allow_guest_to_upload
+        run: |
+          cd ~/frappe-bench/apps/frappe
+          yarn add cypress-file-upload@^5 @4tw/cypress-drag-drop@^2 cypress-real-events @testing-library/cypress@^8 --no-lockfile
+          bench --site test_site execute chat.utils.allow_guest_to_upload
 
       - name: Build Assets
         run: cd ~/frappe-bench/ && bench build

--- a/chat/api/room.py
+++ b/chat/api/room.py
@@ -21,16 +21,25 @@ def get(email):
 
     ).run(as_dict=True)
 
+    user_rooms = []
+
     for room in all_rooms:
         if room['type'] == 'Direct':
             members = room['members'].split(', ')
             room['room_name'] = get_full_name(
                 members[0]) if email == members[1] else get_full_name(members[1])
             room['opposite_person_email'] = members[0] if members[1] == email else members[1]
+        if room['type'] == 'Guest':
+            users = frappe.get_doc("Chat Room", room['name']).users
+            if not users:
+                users = frappe.get_single('Chat Settings').chat_operators
+            if email not in [u.user for u in users]:
+                continue
         room['is_read'] = 1 if email in room['is_read'] else 0
+        user_rooms.append(room)
 
-    all_rooms.sort(key=lambda room: comparator(room))
-    return all_rooms
+    user_rooms.sort(key=lambda room: comparator(room))
+    return user_rooms
 
 
 @frappe.whitelist()

--- a/chat/api/user.py
+++ b/chat/api/user.py
@@ -30,6 +30,7 @@ def validate_guest(email, full_name, message):
         )
 
     if not frappe.db.exists('Chat Profile', email):
+        chat_operators = frappe.get_single('Chat Settings').chat_operators
         profile_doc = frappe.get_doc({
             'doctype': 'Chat Profile',
             'email': email,
@@ -40,7 +41,8 @@ def validate_guest(email, full_name, message):
             'guest': email,
             'room_name': full_name,
             'members': 'Guest',
-            'type': 'Guest'
+            'type': 'Guest',
+            'users': chat_operators or []
         }).insert()
         room = new_room.name
 

--- a/chat/frappe_chat/doctype/chat_room/chat_room.json
+++ b/chat/frappe_chat/doctype/chat_room/chat_room.json
@@ -11,7 +11,8 @@
   "members",
   "last_message",
   "is_read",
-  "guest"
+  "guest",
+  "users"
  ],
  "fields": [
   {
@@ -52,15 +53,20 @@
    "fieldtype": "Select",
    "label": "Type",
    "options": "Group\nGuest\nDirect"
+  },
+  {
+   "fieldname": "users",
+   "fieldtype": "Table MultiSelect",
+   "label": "Users",
+   "options": "Chat Room User"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-10-15 18:43:11.642214",
+ "modified": "2022-08-30 20:12:02.597060",
  "modified_by": "Administrator",
  "module": "Frappe Chat",
  "name": "Chat Room",
- "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {

--- a/chat/frappe_chat/doctype/chat_room_user/chat_room_user.json
+++ b/chat/frappe_chat/doctype/chat_room_user/chat_room_user.json
@@ -1,0 +1,32 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-08-30 16:39:49.583605",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "user"
+ ],
+ "fields": [
+  {
+   "fieldname": "user",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "User",
+   "options": "User",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2022-08-30 20:11:17.530642",
+ "modified_by": "Administrator",
+ "module": "Frappe Chat",
+ "name": "Chat Room User",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/chat/frappe_chat/doctype/chat_room_user/chat_room_user.py
+++ b/chat/frappe_chat/doctype/chat_room_user/chat_room_user.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ChatRoomUser(Document):
+	pass

--- a/chat/frappe_chat/doctype/chat_settings/chat_settings.json
+++ b/chat/frappe_chat/doctype/chat_settings/chat_settings.json
@@ -8,6 +8,7 @@
   "enable_chat",
   "start_time",
   "end_time",
+  "chat_operators",
   "allowed_roles"
  ],
  "fields": [
@@ -37,12 +38,18 @@
    "fieldtype": "Table",
    "label": "Allowed Roles",
    "options": "Has Role"
+  },
+  {
+   "fieldname": "chat_operators",
+   "fieldtype": "Table MultiSelect",
+   "label": "Chat Operators",
+   "options": "Chat Room User"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-10-15 17:37:29.492775",
+ "modified": "2022-08-30 20:13:35.769719",
  "modified_by": "Administrator",
  "module": "Frappe Chat",
  "name": "Chat Settings",

--- a/chat/utils/__init__.py
+++ b/chat/utils/__init__.py
@@ -92,6 +92,8 @@ def get_chat_settings():
 
     if not chat_settings.enable_chat or not has_common(allowed_roles, user_roles):
         return result
+    
+    chat_settings.chat_operators = [co.user for co in chat_settings.chat_operators]
 
     if chat_settings.start_time and chat_settings.end_time:
         start_time = datetime.time.fromisoformat(chat_settings.start_time)
@@ -187,10 +189,10 @@ def is_user_allowed_in_room(room, email, user=None):
         return False
 
     room_detail = get_room_detail(room)
-    if frappe.session.user == "Guest" and room_detail.guest != email:
+    if frappe.session.user == "Guest" and room_detail and room_detail.guest != email:
         return False
 
-    if frappe.session.user != "Guest" and room_detail.type != 'Guest' and email not in room_detail.members:
+    if frappe.session.user != "Guest" and room_detail and room_detail.type != 'Guest' and email not in room_detail.members:
         return False
 
     return True


### PR DESCRIPTION
We used to have this feature in the older version of the chat app.

Added Chat operators table multi-select field in chat settings
Now messages from the guest users will only be visible to the users mentioned in the chat operators field.
Also added users table multi-select field in Chat Room doctype. 

In Chat Settings **shariq@frappe.io** is the chat operator. And you can see he is able to see the **John Doe Guest User's** message
<img width="1375" alt="image" src="https://user-images.githubusercontent.com/30859809/187475250-fa832b2a-ca56-483f-b877-bb7d0cce78f5.png">

Jane Doe is a company user and she can only see a direct message from the company user
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/30859809/187475823-1929176b-5c52-41e8-87e4-54703d362041.png">

Guest User
<img width="1238" alt="image" src="https://user-images.githubusercontent.com/30859809/187476080-8e05c5bc-4675-402a-8ff3-7b9a3259ebe9.png">




We already have a members field in Chat Room which stores the user's name as a comma separate value. 
Need suggestion should we use a text field or a multi-select field for this? I think multi-select should be the obvious choice but why it was implemented as a text field? Security reasons?