### PR TITLE
fix: Logical error in chat.utils.validate_token

### DIFF
--- a/chat/utils/__init__.py
+++ b/chat/utils/__init__.py
@@ -20,15 +20,12 @@ def validate_token(token):
     """
     if not token:
         return [False, {}]
-    is_exist = frappe.db.exists({
-        'doctype': 'Chat Profile',
-        'token': token,
-    })
+    
+    profiles = frappe.get_all('Chat Profile', filters={'token':token})
 
-    if not is_exist:
+    if not profiles:
         return [False, {}]
-
-    guest_user = frappe.get_doc('Chat Profile', str(is_exist[0][0]))
+    guest_user = frappe.get_doc('Chat Profile', profiles[0]['name'])
 
     if guest_user.ip_address != frappe.local.request_ip:
         return [False, {}]

--- a/chat/utils/__init__.py
+++ b/chat/utils/__init__.py
@@ -20,15 +20,15 @@ def validate_token(token):
     """
     if not token:
         return [False, {}]
-    is_exist = frappe.db.exists({
+    chat_profile = frappe.db.get_value({
         'doctype': 'Chat Profile',
         'token': token,
     })
 
-    if not is_exist:
+    if not chat_profile:
         return [False, {}]
 
-    guest_user = frappe.get_doc('Chat Profile', str(is_exist[0][0]))
+    guest_user = frappe.get_doc('Chat Profile', str(chat_profile))
 
     if guest_user.ip_address != frappe.local.request_ip:
         return [False, {}]
@@ -95,7 +95,7 @@ def get_chat_settings():
 
     if not chat_settings.enable_chat or not has_common(allowed_roles, user_roles):
         return result
-    
+
     chat_settings.chat_operators = [co.user for co in chat_settings.chat_operators]
 
     if chat_settings.start_time and chat_settings.end_time:

--- a/chat/utils/__init__.py
+++ b/chat/utils/__init__.py
@@ -20,12 +20,15 @@ def validate_token(token):
     """
     if not token:
         return [False, {}]
-    
-    profiles = frappe.get_all('Chat Profile', filters={'token':token})
+    is_exist = frappe.db.exists({
+        'doctype': 'Chat Profile',
+        'token': token,
+    })
 
-    if not profiles:
+    if not is_exist:
         return [False, {}]
-    guest_user = frappe.get_doc('Chat Profile', profiles[0]['name'])
+
+    guest_user = frappe.get_doc('Chat Profile', str(is_exist[0][0]))
 
     if guest_user.ip_address != frappe.local.request_ip:
         return [False, {}]


### PR DESCRIPTION
frappe.db.is_exit dont return any record because it only returns bolean. We cannot use it as reference to get a chat profile document. Thats why when ever this function is called application gives error:
Wrong line: guest_user = frappe.get_doc(‘Chat Profile’, str(is_exist[0][0]))