### PR TITLE
refactor: publish_realtime + APIs

### DIFF
--- a/chat/api/message.py
+++ b/chat/api/message.py
@@ -4,11 +4,11 @@ from chat.utils import update_room, is_user_allowed_in_room, raise_not_authorize
 
 
 @frappe.whitelist(allow_guest=True)
-def send(content, user, room, email):
+def send(content: str, user: str, room: str, email: str):
     """Send the message via socketio
 
     Args:
-        message (str): Message to be sent.
+        content (str): Message to be sent.
         user (str): Sender's name.
         room (str): Room's name.
         email (str): Sender's email.
@@ -16,41 +16,48 @@ def send(content, user, room, email):
     if not is_user_allowed_in_room(room, email, user):
         raise_not_authorized_error()
 
-    new_message = frappe.get_doc({
-        'doctype': 'Chat Message',
-        'content': content,
-        'sender': user,
-        'room': room,
-        'sender_email': email
-    }).insert()
+    new_message = frappe.get_doc(
+        {
+            "doctype": "Chat Message",
+            "content": content,
+            "sender": user,
+            "room": room,
+            "sender_email": email,
+        }
+    ).insert()
+
     update_room(room=room, last_message=content)
 
     result = {
-        'content': content,
-        'user': user,
-        'creation': new_message.creation,
-        'room': room,
-        'sender_email': email
+        "content": content,
+        "user": user,
+        "creation": new_message.creation,
+        "room": room,
+        "sender_email": email,
     }
-
     typing_data = {
-        'room': room,
-        'user': user,
-        'is_typing': 'false',
-        'is_guest': 'true' if user == 'Guest' else 'false',
+        "room": room,
+        "user": user,
+        "is_typing": "false",
+        "is_guest": "true" if user == "Guest" else "false",
     }
-    typing_event = room + ':typing'
+    typing_event = f"{room}:typing"
 
-    frappe.publish_realtime(event=room, message=result, after_commit=True)
-
-    frappe.publish_realtime(event='latest_chat_updates',
-                            message=result, after_commit=True)
-    frappe.publish_realtime(event=typing_event,
-                            message=typing_data, after_commit=True)
+    for chat_user in frappe.get_cached_doc("Chat Room", room).get_members():
+        frappe.publish_realtime(event=typing_event, user=chat_user, message=typing_data)
+        frappe.publish_realtime(
+            event=room, message=result, user=chat_user, after_commit=True
+        )
+        frappe.publish_realtime(
+            event="latest_chat_updates",
+            message=result,
+            user=chat_user,
+            after_commit=True,
+        )
 
 
 @frappe.whitelist(allow_guest=True)
-def get_all(room, email):
+def get_all(room: str, email: str):
     """Get all the messages of a particular room
 
     Args:
@@ -60,30 +67,30 @@ def get_all(room, email):
     if not is_user_allowed_in_room(room, email):
         raise_not_authorized_error()
 
-    result = frappe.db.get_all('Chat Message',
-                               filters={
-                                   'room': room,
-                               },
-                               fields=['content', 'sender',
-                                       'creation', 'sender_email'],
-                               order_by='creation asc'
-                               )
-    return result
+    return frappe.get_all(
+        "Chat Message",
+        filters={
+            "room": room,
+        },
+        fields=["content", "sender", "creation", "sender_email"],
+        order_by="creation asc",
+    )
 
 
 @frappe.whitelist()
-def mark_as_read(room):
+def mark_as_read(room: str):
     """Mark the message as read
 
     Args:
         room (str): Room's name.
     """
-    frappe.enqueue('chat.utils.update_room', room=room,
-                   is_read=1, update_modified=False)
+    frappe.enqueue(
+        "chat.utils.update_room", room=room, is_read=1, update_modified=False
+    )
 
 
 @frappe.whitelist(allow_guest=True)
-def set_typing(room, user, is_typing, is_guest):
+def set_typing(room: str, user: str, is_typing: bool, is_guest: bool):
     """Set the typing text accordingly
 
     Args:
@@ -92,12 +99,8 @@ def set_typing(room, user, is_typing, is_guest):
         is_typing (bool): Whether user is typing.
         is_guest (bool): Whether user is guest or not.
     """
-    result = {
-        'room': room,
-        'user': user,
-        'is_typing': is_typing,
-        'is_guest': is_guest
-    }
-    event = room + ':typing'
-    frappe.publish_realtime(event=event,
-                            message=result)
+    result = {"room": room, "user": user, "is_typing": is_typing, "is_guest": is_guest}
+    event = f"{room}:typing"
+
+    for chat_user in frappe.get_cached_doc("Chat Room", room).get_members():
+        frappe.publish_realtime(event=event, user=chat_user, message=result)

--- a/chat/api/user.py
+++ b/chat/api/user.py
@@ -1,75 +1,87 @@
 import frappe
 from frappe import _
 from frappe.utils import validate_email_address
+from typing import Tuple, Dict
+from functools import wraps
+
+
+def validate_room_kwargs(function):
+    @wraps(function)
+    def _validator(**kwargs):
+        if not kwargs["full_name"]:
+            frappe.throw(title="Error", msg=_("Full Name is required"))
+        if not kwargs["message"]:
+            frappe.throw(title="Error", msg=_("Message is too short"))
+        validate_email_address(kwargs["email"], throw=True)
+        return function(**kwargs)
+
+    return _validator
+
+
+def generate_guest_room(email: str, full_name: str, message: str) -> Tuple[str, str]:
+    chat_operators = frappe.get_cached_doc("Chat Settings").chat_operators or []
+    profile_doc = frappe.get_doc(
+        {
+            "doctype": "Chat Profile",
+            "email": email,
+            "guest_name": full_name,
+        }
+    ).insert()
+    new_room = frappe.get_doc(
+        {
+            "doctype": "Chat Room",
+            "guest": email,
+            "room_name": full_name,
+            "members": "Guest",
+            "type": "Guest",
+            "users": chat_operators,
+        }
+    ).insert()
+    room = new_room.name
+
+    profile = {
+        "room_name": full_name,
+        "last_message": message,
+        "last_date": new_room.modified,
+        "room": room,
+        "is_read": 0,
+        "room_type": "Guest",
+    }
+
+    for operator in chat_operators:
+        frappe.publish_realtime(
+            event="new_room_creation",
+            message=profile,
+            after_commit=True,
+            user=operator,
+        )
+
+    return room, profile_doc.token
 
 
 @frappe.whitelist(allow_guest=True)
-def validate_guest(email, full_name, message):
-    """Validate the guest user
+@validate_room_kwargs
+def get_guest_room(*, email: str, full_name: str, message: str) -> Dict[str, str]:
+    """Validate and setup profile & room for the guest user
 
     Args:
         email (str): Email of guest.
         full_name (str): Full name of guest.
         message (str): Message to be dropped.
-
     """
-    if not validate_email_address(email):
-        frappe.throw(
-            title='Error',
-            msg=_('Invalid email address')
-        )
-    if not full_name:
-        frappe.throw(
-            title='Error',
-            msg=_('Full Name is required')
-        )
-    if not message:
-        frappe.throw(
-            title='Error',
-            msg=_('Message is too short')
-        )
-
-    if not frappe.db.exists('Chat Profile', email):
-        chat_operators = frappe.get_single('Chat Settings').chat_operators
-        profile_doc = frappe.get_doc({
-            'doctype': 'Chat Profile',
-            'email': email,
-            'guest_name': full_name,
-        }).insert()
-        new_room = frappe.get_doc({
-            'doctype': 'Chat Room',
-            'guest': email,
-            'room_name': full_name,
-            'members': 'Guest',
-            'type': 'Guest',
-            'users': chat_operators or []
-        }).insert()
-        room = new_room.name
-
-        # New room will be created on client side
-        profile = {
-            'room_name': full_name,
-            'last_message': message,
-            'last_date': new_room.modified,
-            'room': room,
-            'is_read': 0,
-            'room_type': 'Guest'
-        }
-        token = profile_doc.token
-        frappe.publish_realtime(event='new_room_creation',
-                                message=profile, after_commit=True)
+    if not frappe.db.exists("Chat Profile", email):
+        room, token = generate_guest_room(email, full_name, message)
 
     else:
-        token = frappe.get_doc('Chat Profile', email).token
-        room = frappe.db.get_value('Chat Room', {'guest': email}, 'name')
+        room = frappe.db.get_value("Chat Room", {"guest": email}, "name")
+        token = frappe.db.get_value("Chat Profile", email, "token")
 
-    result = {
-        'email': email,
-        'guest_name': 'Guest',
-        'message': message,
-        'room': room,
-        'room_name': full_name,
-        'room_type': 'Guest',
-        'token': token
+    return {
+        "guest_name": "Guest",
+        "room_type": "Guest",
+        "email": email,
+        "room_name": full_name,
+        "message": message,
+        "room": room,
+        "token": token,
     }
-    return result

--- a/chat/frappe_chat/doctype/chat_room/chat_room.py
+++ b/chat/frappe_chat/doctype/chat_room/chat_room.py
@@ -5,4 +5,7 @@
 from frappe.model.document import Document
 
 class ChatRoom(Document):
-	pass
+	def get_members(self):
+		if self.members:
+			return [x.strip() for x in self.members.split(",")]
+		return []

--- a/chat/public/js/components/chat_utils.js
+++ b/chat/public/js/components/chat_utils.js
@@ -113,7 +113,7 @@ async function mark_message_read(room) {
 
 async function create_guest({ email, full_name, message }) {
   const res = await frappe.call({
-    method: 'chat.api.user.validate_guest',
+    method: 'chat.api.user.get_guest_room',
     args: {
       email: email,
       full_name: full_name,

--- a/chat/utils/__init__.py
+++ b/chat/utils/__init__.py
@@ -81,7 +81,7 @@ def get_chat_settings():
     Returns:
         dict: Dictionary containing chat settings.
     """
-    chat_settings = frappe.get_single('Chat Settings')
+    chat_settings = frappe.get_cached_doc('Chat Settings')
     user_roles = frappe.get_roles()
 
     allowed_roles = [u.role for u in chat_settings.allowed_roles]

--- a/cypress/integration/chat.js
+++ b/cypress/integration/chat.js
@@ -34,7 +34,7 @@ describe('Guest View', () => {
       method: 'POST',
       url: '/',
       headers: {
-        'X-Frappe-CMD': 'chat.api.user.validate_guest',
+        'X-Frappe-CMD': 'chat.api.user.get_guest_room',
       },
     }).as('submit');
 


### PR DESCRIPTION
- Only bother the operators and not all site users
- Publish typing + other events only to chat room users
- Use cached chat room docs for convenience + perf
- Rename API to mirror actions better
- Split API into bite sized blocks
- Use cached chat settings for better perf
- Reduced logic for better readability
- Styled with black