### PR TITLE
Truncate message content when setting last_message of a Chat Room

### DIFF
--- a/chat/api/message.py
+++ b/chat/api/message.py
@@ -26,7 +26,7 @@ def send(content: str, user: str, room: str, email: str):
         }
     ).insert(ignore_permissions=True)
 
-    update_room(room=room, last_message=content)
+    update_room(room=room, last_message=content[0:140])
 
     result = {
         "content": content,


### PR DESCRIPTION
Following https://github.com/frappe/chat/issues/67 

I simply fixed the bug by trucating the message content when updating the room.
It now works correctly as shown below: 

![image](https://github.com/frappe/chat/assets/108365268/97bfc433-087b-492f-96ae-694060ae2455)

If the content is a file it works aswell